### PR TITLE
Add building castle tile and implement tagging system for hexagonal tiles

### DIFF
--- a/Tiles.wlp
+++ b/Tiles.wlp
@@ -43,6 +43,11 @@
             "fileName": "assets/tiles/hex_road_A.gltf",
             "importerName": "",
             "importPhysicalAsPhongMaterials": true
+        },
+        "5": {
+            "fileName": "assets/tiles/building_castle_blue.gltf",
+            "importerName": "",
+            "importPhysicalAsPhongMaterials": true
         }
     },
     "images": {
@@ -337,6 +342,12 @@
                 "name": "hex_road_A",
                 "file": "assets\\tiles\\hex_road_A.gltf"
             }
+        },
+        "4": {
+            "link": {
+                "name": "building_castle_blue",
+                "file": "assets\\tiles\\building_castle_blue.gltf"
+            }
         }
     },
     "morphTargets": {},
@@ -364,6 +375,12 @@
             "link": {
                 "name": "texture_0",
                 "file": "assets\\tiles\\hex_road_A.gltf"
+            }
+        },
+        "5": {
+            "link": {
+                "name": "texture_0",
+                "file": "assets\\tiles\\building_castle_blue.gltf"
             }
         }
     },
@@ -405,6 +422,12 @@
             "link": {
                 "name": "hexagons_medieval",
                 "file": "assets\\tiles\\hex_road_A.gltf"
+            }
+        },
+        "5": {
+            "link": {
+                "name": "hexagons_medieval",
+                "file": "assets\\tiles\\building_castle_blue.gltf"
             }
         }
     },
@@ -529,6 +552,24 @@
                     "mesh": {
                         "material": "2",
                         "mesh": "3"
+                    }
+                }
+            ]
+        },
+        "8": {
+            "name": "BuildingCastle"
+        },
+        "9": {
+            "link": {
+                "name": "building_castle_blue",
+                "file": "assets\\tiles\\building_castle_blue.gltf"
+            },
+            "parent": "8",
+            "components": [
+                {
+                    "originalIndex": 0,
+                    "mesh": {
+                        "material": "2"
                     }
                 }
             ]

--- a/TownBuilder.wlp
+++ b/TownBuilder.wlp
@@ -203,7 +203,7 @@
                         "material": "7",
                         "mesh": "8"
                     },
-                    "active": true
+                    "active": false
                 }
             ],
             "scaling": [

--- a/js/classes/HexGrid.ts
+++ b/js/classes/HexGrid.ts
@@ -1,5 +1,5 @@
-import { HexagonTile } from './HexagonTile.js';
-import { TileType } from './TileType.js';
+import {HexagonTile} from './HexagonTile.js';
+import {TileType} from './TileType.js';
 
 /**
  * Represents a grid of hexagonal tiles.
@@ -15,8 +15,6 @@ export class HexagonGrid {
      */
     constructor() {
         this._tiles = new Map();
-        // Add the center tile
-        this.addTile(new HexagonTile(0, 0, 0, TileType.Castle));
     }
 
     /**
@@ -49,7 +47,11 @@ export class HexagonGrid {
      * @returns The hexagon tile at the specified coordinates, or undefined if not found.
      */
     public getTile(x: number, y: number, z: number): HexagonTile | undefined {
-        return this._tiles.get(this.getKey(x, y, z));
+        return this.getTileById(this.getKey(x, y, z));
+    }
+
+    public getTileById(id: string): HexagonTile | undefined {
+        return this._tiles.get(id);
     }
 
     /**

--- a/js/classes/HexagonTile.ts
+++ b/js/classes/HexagonTile.ts
@@ -1,5 +1,6 @@
 import {Object3D} from '@wonderlandengine/api';
 import {TileType} from './TileType.js';
+import {Tags} from './Tags.js';
 
 /**
  * The size of a hexagon tile, calculated based on the hexagon geometry.
@@ -15,6 +16,13 @@ export class HexagonTile {
      */
     private _object!: Object3D;
 
+    private _id: string;
+    private tags: Set<string> = new Set();
+
+    public get id(): string {
+        return this._id;
+    }
+
     /**
      * Creates a new HexagonTile instance.
      * @param x - The x-coordinate in cube coordinates.
@@ -28,7 +36,9 @@ export class HexagonTile {
         public z: number,
         public type: TileType = TileType.Grass,
         public elevation: number = 0
-    ) {}
+    ) {
+        this._id = `${x},${y},${z}`;
+    }
 
     /**
      * Gets the 3D object associated with this tile.
@@ -115,5 +125,13 @@ export class HexagonTile {
         }
 
         return [rx, ry, rz];
+    }
+
+    public addTag(tag: string): void {
+        Tags.setTag(tag, this._id);
+    }
+
+    public hasTag(tag: string): boolean {
+        return Tags.hasTag(tag, this._id);
     }
 }

--- a/js/classes/Tags.ts
+++ b/js/classes/Tags.ts
@@ -1,0 +1,66 @@
+import {HexagonTile} from './HexagonTile.js';
+
+export class Tags {
+    private static _instance: Tags;
+
+    private _tagList: Map<string, Set<string>> = new Map();
+
+    private static get instance(): Tags {
+        if (!Tags._instance) {
+            Tags._instance = new Tags();
+        }
+        return Tags._instance;
+    }
+
+    private constructor() {}
+
+    static setTag(tag: string, hexagonTileID: string): void {
+        const instance = Tags.instance;
+
+        if (!instance._tagList.has(tag)) {
+            instance._tagList.set(tag, new Set());
+        }
+
+        instance._tagList.get(tag)?.add(hexagonTileID);
+    }
+
+    static getTags(hexagonTileID: string): string[] {
+        const instance = Tags.instance;
+        const tags: string[] = [];
+
+        for (const [tag, tileIDs] of instance._tagList.entries()) {
+            if (tileIDs.has(hexagonTileID)) {
+                tags.push(tag);
+            }
+        }
+
+        return tags;
+    }
+
+    static hasTag(tag: string, hexagonTileID: string): boolean {
+        const instance = Tags.instance;
+        return instance._tagList.get(tag)?.has(hexagonTileID) ?? false;
+    }
+
+    static removeTag(tag: string, hexagonTileID: string): boolean {
+        const instance = Tags.instance;
+
+        if (instance._tagList.has(tag)) {
+            const tileIDs = instance._tagList.get(tag);
+            if (tileIDs?.delete(hexagonTileID)) {
+                // If the tag no longer has any associated tiles, remove the tag entirely
+                if (tileIDs.size === 0) {
+                    instance._tagList.delete(tag);
+                }
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    static getTilesWithTag(tag: string): string[] {
+        const instance = Tags.instance;
+        return Array.from(instance._tagList.get(tag) || []);
+    }
+}


### PR DESCRIPTION
Introduce a new building tile for castles and implement a tagging system for hexagonal tiles to enhance tile management and functionality. This update allows for better organization and identification of tiles within the grid.